### PR TITLE
Fix "linking against a dylib which is not safe for use in application extensions"

### DIFF
--- a/BadgeSwift.xcodeproj/project.pbxproj
+++ b/BadgeSwift.xcodeproj/project.pbxproj
@@ -567,6 +567,7 @@
 		7E1365981D1915E000C7468A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -588,6 +589,7 @@
 		7E1365991D1915E000C7468A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
Solves https://github.com/evgenyneu/swift-badge/issues/23